### PR TITLE
Add `allowFail`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.cabal-sandbox
+cabal.sandbox.config
+dist
+.stack-work/
+tags

--- a/Test/Tasty/ExpectedFailure.hs
+++ b/Test/Tasty/ExpectedFailure.hs
@@ -14,7 +14,7 @@ instance forall t. IsTest t => IsTest (WrappedTest t) where
     run opts (WrappedTest wrap t) prog = wrap (run opts t prog)
     testOptions = retag (testOptions :: Tagged t [OptionDescription])
 
--- | 'wrapTest' allows you to modify the behavoiur of the tests, e.g. by
+-- | 'wrapTest' allows you to modify the behaviour of the tests, e.g. by
 -- modifying the result or not running the test at all. It is used to implement
 -- 'expectFail' and 'ignoreTest'.
 wrapTest :: (IO Result -> IO Result) -> TestTree -> TestTree
@@ -29,17 +29,17 @@ wrapTest wrap = go
 
 -- | Marks all tests in the give test as expected failures: The tests will
 -- still be run, but if they succeed, it is reported as a test suite failure,
--- and conversely a the failure of the test is ignored.
+-- and conversely a failure of the test is ignored.
 --
 -- Any output of a failing test is still printed.
 --
 -- This is useful if, in a test driven development, tests are written and
--- commited to the master branch before their implementation: It allows the
+-- committed to the master branch before their implementation: It allows the
 -- tests to fail (as expected) without making the whole test suite fail.
 --
 -- Similarly, regressions and bugs can be documented in the test suite this
--- way, until a fix is commited, and if a fix is applied (intentionally or
--- accidentially), the test suite will remind you to remove the 'expectFail'
+-- way, until a fix is committed, and if a fix is applied (intentionally or
+-- accidentally), the test suite will remind you to remove the 'expectFail'
 -- marker.
 expectFail :: TestTree -> TestTree
 expectFail = wrapTest (fmap change)
@@ -61,7 +61,7 @@ expectFail = wrapTest (fmap change)
 
 
 -- | Prevents the tests from running and reports them as succeeding. This maybe
--- be desireable as an alternative comment the tests out, as they are still
+-- be desirable as an alternative comment the tests out, as they are still
 -- typechecked, and the test report lists them, as a reminder that there are
 -- ignored test.
 ignoreTest :: TestTree -> TestTree


### PR DESCRIPTION
This is like `expectFail` but marks passing tests as successes. This is a workaround for expecting at least one test to fail under a `TestTree` with multiple leaves.

Ideally, for my particular use case, if all tests succeed, it should be reported as an unexpected failure, but right now I don't have time to figure out how to do so. I guess I'd have to write another version of `wrapTest` with some `TestTree` folding.
