### PR TITLE
Catch exceptions before negating result

### DIFF
--- a/tasty-expected-failure.cabal
+++ b/tasty-expected-failure.cabal
@@ -1,5 +1,5 @@
 name:                tasty-expected-failure
-version:             0.11.0.3
+version:             0.11.0.4
 synopsis:            Mark tasty tests as failure expected
 description:
  With the function 'Test.Tasty.ExpectedFailure.expectFail' in the provided module


### PR DESCRIPTION
Fixes #3 

This involved copying some code from `tasty` because it wasn't exported.
