### PR TITLE
Tests and exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,18 +47,6 @@ jobs:
     - compiler: ghc-8.0.2
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.0.2","cabal-install-3.0"]}}
       os: linux
-    - compiler: ghc-7.10.3
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.10.3","cabal-install-3.0"]}}
-      os: linux
-    - compiler: ghc-7.8.4
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.8.4","cabal-install-3.0"]}}
-      os: linux
-    - compiler: ghc-7.6.3
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.6.3","cabal-install-3.0"]}}
-      os: linux
-    - compiler: ghc-7.4.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.4.2","cabal-install-3.0"]}}
-      os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - WITHCOMPILER="-w $HC"

--- a/Test/Tasty/ExpectedFailure.hs
+++ b/Test/Tasty/ExpectedFailure.hs
@@ -56,13 +56,13 @@ expectFail' reason = wrapTest (fmap change)
     change r
         | resultSuccessful r
         = r { resultOutcome = Failure TestFailed
-            , resultDescription = resultDescription r <> "(unexpected success" <> comment <> ")"
-            , resultShortDescription = "PASS (unexpected" <> comment <> ")"
+            , resultDescription = resultDescription r <> " (unexpected success" <> comment <> ")"
+            , resultShortDescription = resultShortDescription r <> " (unexpected" <> comment <> ")"
             }
         | otherwise
         = r { resultOutcome = Success
-            , resultDescription = resultDescription r <> "(expected failure)"
-            , resultShortDescription = "FAIL (expected" <> comment <> ")"
+            , resultDescription = resultDescription r <> " (expected failure)"
+            , resultShortDescription = resultShortDescription r <> " (expected" <> comment <> ")"
             }
     "" `append` s = s
     t  `append` s | last t == '\n' = t ++ s ++ "\n"

--- a/Test/Tasty/ExpectedFailure.hs
+++ b/Test/Tasty/ExpectedFailure.hs
@@ -18,7 +18,12 @@ data WrappedTest t = WrappedTest (IO Result -> IO Result) t
 
 instance forall t. IsTest t => IsTest (WrappedTest t) where
     run opts (WrappedTest wrap t) prog =
-      -- re-implement timeouts and exception handling *inside* the wrapper
+      -- Re-implement timeouts and exception handling *inside* the
+      -- wrapper.  The primary location for timeout and exception
+      -- handling is in `executeTest` in the Tasty module's
+      -- Test.Tasty.Run implementation, but that handling is above the
+      -- level of this wrapper which therefore cannot absorb timeouts
+      -- and exceptions as *expected* failures.
       let (pre,post) = case lookupOption opts of
                          NoTimeout -> (fmap Just, fromJust)
                          Timeout t s -> (timeout (faster t), fromMaybe (timeoutResult t s))

--- a/tasty-expected-failure.cabal
+++ b/tasty-expected-failure.cabal
@@ -41,3 +41,26 @@ library
 source-repository head
   type:     git
   location: git://github.com/nomeata/tasty-expected-failure
+
+
+test-suite expected-fail-tests
+  type: exitcode-stdio-1.0
+  default-language:    Haskell2010
+  hs-source-dirs:      tests
+  main-is:             TestExpectedFails.hs
+  build-depends:       base,
+                       tasty,
+                       tasty-hunit,
+                       tasty-expected-failure
+
+
+test-suite expected-fail-hh-tests
+  type: exitcode-stdio-1.0
+  default-language:    Haskell2010
+  hs-source-dirs:      tests
+  main-is:             TestExpectedFailsHH.hs
+  build-depends:       base,
+                       hedgehog,
+                       tasty,
+                       tasty-hedgehog,
+                       tasty-expected-failure

--- a/tasty-expected-failure.cabal
+++ b/tasty-expected-failure.cabal
@@ -27,13 +27,13 @@ category:            Testing
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
-tested-with: GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
+tested-with: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
 
 library
   exposed-modules:
     Test.Tasty.ExpectedFailure
   build-depends:
-    base >= 4.5 && <5,
+    base >= 4.9 && <5,
     tagged >= 0.7 && < 0.9,
     tasty >= 0.11,
     unbounded-delays < 0.2

--- a/tasty-expected-failure.cabal
+++ b/tasty-expected-failure.cabal
@@ -52,6 +52,7 @@ test-suite expected-fail-tests
   build-depends:       base,
                        tasty,
                        tasty-hunit,
+                       tasty-golden,
                        tasty-expected-failure
 
 

--- a/tasty-expected-failure.cabal
+++ b/tasty-expected-failure.cabal
@@ -35,7 +35,8 @@ library
   build-depends:
     base >= 4.5 && <5,
     tagged >= 0.7 && < 0.9,
-    tasty >= 0.11
+    tasty >= 0.11,
+    unbounded-delays < 0.2
   default-language:    Haskell2010
 
 source-repository head

--- a/tests/TestExpectedFails.hs
+++ b/tests/TestExpectedFails.hs
@@ -1,6 +1,7 @@
+import Control.Concurrent (threadDelay)
 import Test.Tasty
-import Test.Tasty.HUnit
 import Test.Tasty.ExpectedFailure
+import Test.Tasty.HUnit
 
 -- n.b. running via `cabal v2-test` outputs plaintext, but running via
 -- `cabal v2-run test:expected-fail-tests` will generate colorized
@@ -8,7 +9,9 @@ import Test.Tasty.ExpectedFailure
 -- that "PASS (unexpected)" is rendered in Red and "FAIL (expected)"
 -- is rendered in Green.
 
-main = defaultMain $ testGroup "Expected Failures" $
+main = defaultMain $
+  localOption (mkTimeout 1000000) $  -- 1s
+  testGroup "Expected Failures" $
   [ testCase "clearly good" $ 1 + 1 @=? 2
   , expectFail $ testCase "clearly bad" $ 1 + 1 @=? 3
 
@@ -16,4 +19,8 @@ main = defaultMain $ testGroup "Expected Failures" $
   -- , expectFail $ testCase "also good" $ 1 + 2 @=? 3
 
   , expectFail $ expectFail $ testCase "two wrongs make a right" $ 1 + 1 @=? 2
+
+  , expectFail $ testCase "throws failure" $ fail "bad"
+
+  , expectFail $ testCase "takes too long" $ threadDelay 2000000
   ]

--- a/tests/TestExpectedFails.hs
+++ b/tests/TestExpectedFails.hs
@@ -1,0 +1,19 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure
+
+-- n.b. running via `cabal v2-test` outputs plaintext, but running via
+-- `cabal v2-run test:expected-fail-tests` will generate colorized
+-- output.  It's adviseable to visually inspect this output to ensure
+-- that "PASS (unexpected)" is rendered in Red and "FAIL (expected)"
+-- is rendered in Green.
+
+main = defaultMain $ testGroup "Expected Failures" $
+  [ testCase "clearly good" $ 1 + 1 @=? 2
+  , expectFail $ testCase "clearly bad" $ 1 + 1 @=? 3
+
+  -- n.b. uncomment this to observe the results of a test that was
+  -- , expectFail $ testCase "also good" $ 1 + 2 @=? 3
+
+  , expectFail $ expectFail $ testCase "two wrongs make a right" $ 1 + 1 @=? 2
+  ]

--- a/tests/TestExpectedFails.hs
+++ b/tests/TestExpectedFails.hs
@@ -1,6 +1,7 @@
 import Control.Concurrent (threadDelay)
 import Test.Tasty
 import Test.Tasty.ExpectedFailure
+import Test.Tasty.Golden
 import Test.Tasty.HUnit
 
 -- n.b. running via `cabal v2-test` outputs plaintext, but running via
@@ -21,6 +22,9 @@ main = defaultMain $
   , expectFail $ expectFail $ testCase "two wrongs make a right" $ 1 + 1 @=? 2
 
   , expectFail $ testCase "throws failure" $ fail "bad"
+  , expectFail $ testCase "throws error" $ error "also bad"
 
   , expectFail $ testCase "takes too long" $ threadDelay 2000000
+
+  , expectFail $ goldenVsString "hello" "hello.out" $ return $ error "not golden"
   ]

--- a/tests/TestExpectedFailsHH.hs
+++ b/tests/TestExpectedFailsHH.hs
@@ -1,3 +1,5 @@
+import           Control.Concurrent ( threadDelay )
+import           Control.Monad.IO.Class ( liftIO )
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -11,7 +13,9 @@ import           Test.Tasty.Hedgehog
 -- that "PASS (unexpected)" is rendered in Red and "FAIL (expected)"
 -- is rendered in Green.
 
-main = defaultMain $ testGroup "Expected Hedgehog Failures" $
+main = defaultMain $
+  localOption (mkTimeout 1000000) $  -- 1s
+  testGroup "Expected Hedgehog Failures" $
   [ testProperty "good" $ property $ success
   , expectFail $ testProperty "rarely good" $ property $ do
       xs <- forAll $ Gen.list (Range.linear 0 10) Gen.alpha
@@ -25,4 +29,12 @@ main = defaultMain $ testGroup "Expected Hedgehog Failures" $
 
   , expectFail $ expectFail $ testProperty "the failure of a failure is my good" $
     property $ success
+
+  , expectFail $ testProperty "throws failure" $
+    property $ fail "bad"
+
+  , expectFail $ testProperty "too slow" $
+    property $ do
+      liftIO $ threadDelay 2000000
+      success
   ]

--- a/tests/TestExpectedFailsHH.hs
+++ b/tests/TestExpectedFailsHH.hs
@@ -23,7 +23,7 @@ main = defaultMain $
 
   -- n.b. uncomment this to observe the results of a test that was
   -- expected to fail but actually passes.
-  -- , expectFail $ testProperty "surprisingly good" $ property $ failure
+  -- , expectFail $ testProperty "surprisingly good" $ property $ success
 
   , expectFail $ testProperty "giving up" $ property $ discard
 

--- a/tests/TestExpectedFailsHH.hs
+++ b/tests/TestExpectedFailsHH.hs
@@ -1,0 +1,28 @@
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure
+import           Test.Tasty.Hedgehog
+
+-- n.b. running via `cabal v2-test` outputs plaintext, but running via
+-- `cabal v2-run test:expected-fail-tests` will generate colorized
+-- output.  It's adviseable to visually inspect this output to ensure
+-- that "PASS (unexpected)" is rendered in Red and "FAIL (expected)"
+-- is rendered in Green.
+
+main = defaultMain $ testGroup "Expected Hedgehog Failures" $
+  [ testProperty "good" $ property $ success
+  , expectFail $ testProperty "rarely good" $ property $ do
+      xs <- forAll $ Gen.list (Range.linear 0 10) Gen.alpha
+      reverse xs === xs
+
+  -- n.b. uncomment this to observe the results of a test that was
+  -- expected to fail but actually passes.
+  -- , expectFail $ testProperty "surprisingly good" $ property $ failure
+
+  , expectFail $ testProperty "giving up" $ property $ discard
+
+  , expectFail $ expectFail $ testProperty "the failure of a failure is my good" $
+    property $ success
+  ]


### PR DESCRIPTION
Fix Issue #6 and Issue #10 and also allow exceptions to be expected failures.

See notes on the 6fec68f commit.

Drops support for GHC 7.