### PR TITLE
ignoreTestBecause: move the reason to the result description

### DIFF
--- a/Test/Tasty/ExpectedFailure.hs
+++ b/Test/Tasty/ExpectedFailure.hs
@@ -141,6 +141,6 @@ ignoreTestBecause reason = ignoreTest' (Just reason)
 
 ignoreTest' :: Maybe String -> TestTree -> TestTree
 ignoreTest' reason = wrapTest $ const $ return $
-    (testPassed "") {
-      resultShortDescription = "IGNORED" <> maybe "" (mappend ": ") reason
+    (testPassed $ fromMaybe "" reason) {
+      resultShortDescription = "IGNORED"
     }


### PR DESCRIPTION
First of all, thank you for maintaining this package! 😉

I think the 'reason' string looks better when it's moved to the description. The `resultShortDescription` field is intended for short, one-word statuses like "OK", "FAIL", or "IGNORED".

Here's an example before:

![2020-10-10 17:59:42](https://user-images.githubusercontent.com/24844/95658808-e6466280-0b25-11eb-8dd1-8bb5108f7aac.png)

And after:

![2020-10-10 18:21:23](https://user-images.githubusercontent.com/24844/95658810-ec3c4380-0b25-11eb-88f0-c2d8e00556cf.png)

`expectFailBecause` probably should be modified in the same way, but requires other fixes too: e.g. `" (unexpected" <> comment <> ")"` is appended without a space before comment; perhaps you meant to use the `append` function there?